### PR TITLE
こまかい神器のバグの修正

### DIFF
--- a/Asset/data/asset/functions/sacred_treasure/0012.sketchy_herb/3.main.mcfunction
+++ b/Asset/data/asset/functions/sacred_treasure/0012.sketchy_herb/3.main.mcfunction
@@ -11,7 +11,7 @@
 
 # エフェクト効果
     effect give @s minecraft:strength 60 10 true
-    effect give @s minecraft:resistance 60 5 true
+    effect give @s minecraft:resistance 60 2 true
     effect give @s minecraft:nausea 60 0 true
     effect give @s minecraft:poison 15 3 true
     effect give @s minecraft:instant_damage 1 1 true

--- a/Asset/data/asset/functions/sacred_treasure/0188.reverse_transcription_magic/2.check_condition.mcfunction
+++ b/Asset/data/asset/functions/sacred_treasure/0188.reverse_transcription_magic/2.check_condition.mcfunction
@@ -11,7 +11,7 @@
 # 神器の基本的な条件の確認を行うfunction、成功している場合CanUsedタグが付く auto/feet/legs/chest/head/mainhand/offhandを記載してね
     function asset:sacred_treasure/lib/check_condition/auto
 # 他にアイテム等確認する場合はここに書く
-    execute store result score $MPRequire Temporary run data get storage asset:context Items.offhand.tag.TSB.MPRequire
+    execute store result score $MPRequire Temporary run data get storage asset:context Items.offhand.tag.TSB.MPCost
     execute unless score $MPRequire Temporary matches 1.. run tag @s remove CanUsed
     execute unless score $MPRequire Temporary matches 1.. run playsound ui.button.click master @s ~ ~ ~ 1 2
     execute unless score $MPRequire Temporary matches 1.. run tellraw @s [{"text": "オフハンドにMPを消費する神器を持っている必要があります","color": "red"}]

--- a/Asset/data/asset/functions/sacred_treasure/0188.reverse_transcription_magic/3.main.mcfunction
+++ b/Asset/data/asset/functions/sacred_treasure/0188.reverse_transcription_magic/3.main.mcfunction
@@ -16,5 +16,3 @@
         playsound entity.player.levelup master @s ~ ~ ~ 1 1 1
         stopsound @s * entity.item.break
         particle totem_of_undying ~ ~1.5 ~ 0.5 1 0.5 0 100 force @s
-
-        data get entity @s Inventory

--- a/Asset/data/asset/functions/sacred_treasure/0188.reverse_transcription_magic/3.main.mcfunction
+++ b/Asset/data/asset/functions/sacred_treasure/0188.reverse_transcription_magic/3.main.mcfunction
@@ -9,10 +9,12 @@
 
 # ここから先は神器側の効果の処理を書く
     # MPをOffhandItemのMPRequireに設定
-        execute store result score $Set Lib run data get storage asset:context Items.offhand.tag.TSB.MPRequire
-        tellraw @s [{"text": "MPが ["},{"nbt": "Items.offhand.tag.display.Name","entity": "@s","interpret": true},{"text": "] の消費MP [ "},{"score": {"name": "$Set","objective": "Lib"}},{"text": " ] になった！"}]
+        execute store result score $Set Lib run data get storage asset:context Items.offhand.tag.TSB.MPCost
+        tellraw @s [{"text": "MPが ["},{"nbt": "Inventory[{Slot:-106b}].tag.display.Name","storage": "asset:context","interpret": true},{"text": "] の消費MP [ "},{"score": {"name": "$Set","objective": "Lib"}},{"text": " ] になった！"}]
         function lib:mp/set
     # 演出
         playsound entity.player.levelup master @s ~ ~ ~ 1 1 1
         stopsound @s * entity.item.break
         particle totem_of_undying ~ ~1.5 ~ 0.5 1 0.5 0 100 force @s
+
+        data get entity @s Inventory

--- a/Asset/data/asset/functions/sacred_treasure/0610.call_fish/3.2.attack.mcfunction
+++ b/Asset/data/asset/functions/sacred_treasure/0610.call_fish/3.2.attack.mcfunction
@@ -10,6 +10,10 @@
 # 敵の元へテレポート
     tp @s @e[tag=Enemy,sort=nearest,limit=1]
 
+#演出
+    execute at @e[tag=Enemy,sort=nearest,limit=1] run particle minecraft:block water ~ ~ ~ 0.3 0.3 0.3 10 100
+    playsound entity.squid.death master @a ~ ~ ~ 1 2
+
 # ダメージを与える
     # 与えるダメージ
         data modify storage lib: Argument.Damage set value 10.0f
@@ -20,10 +24,6 @@
         execute as @a if score @s UserID = @e[type=cod,tag=9Q.This,limit=1] 9Q.UserID run function lib:damage/modifier
     # 対象に
         execute as @e[tag=Enemy,sort=nearest,limit=1] run function lib:damage/
-
-#演出
-    execute at @e[tag=Enemy,sort=nearest,limit=1] run particle minecraft:block water ~ ~ ~ 0.3 0.3 0.3 10 100
-    playsound entity.squid.death master @a ~ ~ ~ 1 2
 
 # リセット
     data remove storage lib: Argument


### PR DESCRIPTION
怪しい葉っぱの無敵
逆転写魔が使えなかった、tellrawがおかしかったのを修正
コールフィッシュが敵を殺した場合に関係ない敵にパーティクルが出る問題を修正